### PR TITLE
Refactorizacion de parametros de cmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ mkdir build && cd build
 
 Si desea ejecutar Ixchel2D con multicore:
 ```shell
-cmake ../source/ -DENABLE_GPU=OFF
+cmake ../source/ -DGPU=OFF
 make
 ```
 
@@ -71,7 +71,7 @@ El valor `ccXX` es la capacidad de cómputo de la GPU.
 
 Sabiendo la capacidad de cómputo de la GPU, ahora ejecutamos lo siguiente:
 ```shell
-cmake ../source/ -DENABLE_GPU=ON -DCOMPUTE_CAPABILITY=ccXX
+cmake ../source/ -DGPU=ON -DTARGET=ccXX
 make
 ```
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -5,13 +5,13 @@ cmake_minimum_required(VERSION 3.22)
 project(IXCHEL2D LANGUAGES Fortran)
 
 # Configuracion para usar gpu
-option(ENABLE_GPU "Enable GPU use" OFF)
+option(GPU "Enable GPU use" OFF)
 
 if(ENABLE_GPU)
     message(STATUS "Using OpenAcc GPU")
 
     # Arquitectura de GPU a utilizar
-    set(CUDA_ARCHITECTURE ${COMPUTE_CAPABILITY})
+    set(CUDA_ARCHITECTURE ${TARGET})
     message(STATUS "CUDA Architecture: ${CUDA_ARCHITECTURE}")
 
     # Definir el nombre del ejecutable


### PR DESCRIPTION
Se cambian de nombre a las banderas de configuracion de cmake y se
modifica la documentacion con los nuevos nombres.

ENABLE_GPU se cambio a GPU
COMPUTE_CAPABILITY se cambio a TARGET.
